### PR TITLE
Update branding, URL, and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
-# Syntax Highlighter
-Syntax Highlighter is an editable text area enhanced by the [Ace Code Editor](https://ace.c9.io/) to provide a programmer-friendly environment for writing code examples. Offers a fine selection of programming languages to be highlighted.
+# Ace Code Editor Custom Element for Kentico Kontent
+
+The Ace Code Editor custom element is an editable text area enhanced by the [Ace Code Editor](https://ace.c9.io/) to provide syntax highlighting for writing code examples. Offers a fine selection of programming languages to be highlighted.
 
 ![Syntax Highlighter](example.png)
 
-## Usage
+## Setup
 
-If you want to use the Syntax Highlighter in your project in Kentico Cloud, follow these steps:
+If you want to use the Syntax Highlighter in your project in Kentico Kontent, follow these steps:
 
-* Host the Syntax Highlighter code on you end considering [the Kentico recommendations](https://developer.kenticocloud.com/docs/integrating-content-editing-features)
-* In Kentico Cloud open Content types tab
-* Open / create a content model to which you want to add the Syntax Highlighter
-* Add **Custom element** content element
-* Open configuration of the content element
-* Use absolute URL of the index.html file hosted on your end as Hosted code URL (HTTPS)
-* Optional: Provide the following JSON parameters for the custom element to configure the initial state of the Syntax Highlighter
+1. Deploy the code to a secure publis host
+    * See [deploying section](#Deploying) for a really quick option
+1. Follow the instructions in the [Kentico Kontent documentation](https://docs.kontent.ai/tutorials/develop-apps/integrate/integrating-your-own-content-editing-features#a-3--displaying-a-custom-element-in-kentico-kontent) to add the element to a content model.
+    * The `Hosted code URL` is where you deployed to in step 1
+    * You can pass optional configuration based on the documented [JSON Parameters section of the readme](#json-parameters).
+
+## JSON Parameters
+
+You can optionally provide the following JSON parameters for the custom element to configure the initial state of the Syntax Highlighter:
 
 ```json
 {
@@ -25,9 +28,9 @@ If you want to use the Syntax Highlighter in your project in Kentico Cloud, foll
 * **THEME CODENAME** is a filename substring prefixed by **theme-** of a file located in the **ace** folder (i.e. textmate)
 * **PROGRAMMING LANGUAGE CODENAME** is a filename substring prefixed by **mode-** of a file located in the **ace** folder (i.e. plain_text)
 
-## Obtaining value
+## What is saved?
 
-The value contains data about language and code. As Kentico Cloud custom elements can contain only `string` values or `null`, the value is stored as a stringified object. That means the value has to be explicitly parsed. 
+The value contains data about language and code. As Kentico Cloud custom elements can contain only `string` values or `null`, the value is stored as a stringified object. That means the value has to be explicitly parsed.
 
 ### Example
 
@@ -37,9 +40,11 @@ The value contains the following string when obtained from Kentico Cloud:
 ```
 You need to parse that value to get a proper object (i.e. in JavaScript with the use of the `JSON.parse` method).
 
-## Original repository
+## Deploying
 
-Syntax Highlighter source code is in the following repository: https://github.com/MilanLund/ace-kenticocloud-customelement
+Netlify has made this easy. If you click the deploy button below, it will guide you through the process of deploying it to Netlify and leave you with a copy of the repository in your GitHub account as well.
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/MilanLund/ace-kenticocloud-customelement)
 
 ## Licenses
 

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Ace-KC Custom element</title>
     <meta name="author" content="Milan Lund">
     <link rel="stylesheet" type="text/css" href="./custom-element.min.css">
-    <script src="https://app.kenticocloud.com/js-api/custom-element.js" charset="utf-8" defer></script>
+    <script src="https://app.kontent.ai/js-api/custom-element/v1/custom-element.min.js" charset="utf-8" defer></script>
     <script src="./ace/ace.js" type="text/javascript" charset="utf-8" defer></script>
     <script src="./custom-element.min.js" charset="utf-8" defer></script>
 </head>


### PR DESCRIPTION
Hi Milan, 

We're making some changes to the sample gallery and I wanted to get your submission for the Ace Code Editor up-to-date. 

I've updated the URL for the Custom Element API, as well as adjusted the Readme for the rebranding and to add a simple deploy option via Netlify. 

If you approave of the changes, I'd also recommend updating the repo name, description, and topics. You can check out my for my suggestions on that, and they're copied below:

Name: kontent-custom-element-ace-code-editor
Desc: Ace Code Editor custom element for Kentico Kontent
Topics: kentico-kontent kontent custom-element ace-editor

Let me know if you have any questions or comments.